### PR TITLE
Fix the "Change License" modal URL

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -534,8 +534,8 @@ class CreativeCommons {
 	$html = <<<CONTENT
 
 	<span id='license-display'></span>
-        <br id="license">
-        {$link}
+	<br id="license">
+	{$link}
 
 	<input type="hidden" value="{$license['deed']}" id="hidden-license-deed" name="license[deed]"/>
 	<input type="hidden" value="{$license['image']}" id="hidden-license-image" name="license[image]"/>

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -524,7 +524,7 @@ class CreativeCommons {
 	}
 
 	// Link.
-	$link = sprintf( '<a title="$1$s" class="button button-secondary thickbox edit-license" href="%2$s">%3$s</a>',
+	$link = sprintf( '<a title="%1$s" class="button button-secondary thickbox edit-license" href="%2$s">%3$s</a>',
 		__( 'Choose a Creative Commons license', $this->localization_domain ),
 		add_query_arg( $link_args, 'https://creativecommons.org/choose/' ),
 		__( 'Change license', $this->localization_domain )

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -506,28 +506,48 @@ class CreativeCommons {
         // get the previously selected license from this site's options
         // or the plugin's default license
         //$license = get_option('license', $this->plugin_default_license());
-        $license  = $this->get_license($location);
-        // add lang option
-        $lang = (isset($this->locale) && ! empty($this->locale))
-              ? 'lang=' . esc_attr($this->locale) : '';
+	$license = $this->get_license( $location );
 
-        $html = '';
-        $html .= "<span id='license-display'></span>";
-        $html .= '<br id="license"><a title="' . __('Choose a Creative Commons license', $this->localization_domain) . '" class="button button-secondary thickbox edit-license" href="https://creativecommons.org/choose/?';
-        $html .= 'partner=CC+WordPress+Plugin&';
-        $html .= $lang;
-        $html .= '&exit_url=' . $this->plugin_url . 'license-return.php?url=[license_url]%26name=[license_name]%26button=[license_button]%26deed=[deed_url]&';
-        $html .= '&KeepThis=true&TB_iframe=true&height=500&width=600">' . __('Change license', $this->localization_domain);
-        $html .=  '</a>';
+	// Set up link arguments.
+	$link_args = array(
+		'partner'   => 'CC+WordPress+Plugin',
+		'exit_url'  => urlencode( $this->plugin_url ) . 'license-return.php?url=[license_url]%26name=[license_name]%26button=[license_button]%26deed=[deed_url]',
+		'KeepThis'  => 'true',
+		'TB_iframe' => 'true',
+		'height'    => 500,
+		'width'     => 600
+	);
 
-        $html .= '<input type="hidden" value="'.$license['deed'].'" id="hidden-license-deed" name="license[deed]"/>';
-        $html .= '<input type="hidden" value="'.$license['image'].'" id="hidden-license-image" name="license[image]"/>';
-        $html .= '<input type="hidden" value="'.$license['name'].'" id="hidden-license-name" name="license[name]"/>';
-        if ($echo) {
-            echo $html;
-        } else {
-            return $html;
-        }
+	// Set lang if available.
+	if ( isset( $this->locale ) && ! empty( $this->locale ) ) {
+		$link_args['lang'] = esc_attr( $this->locale );
+	}
+
+	// Link.
+	$link = sprintf( '<a title="$1$s" class="button button-secondary thickbox edit-license" href="%2$s">%3$s</a>',
+		__( 'Choose a Creative Commons license', $this->localization_domain ),
+		add_query_arg( $link_args, 'https://creativecommons.org/choose/' ),
+		__( 'Change license', $this->localization_domain )
+	);
+
+	// HTML markup.
+	$html = <<<CONTENT
+
+	<span id='license-display'></span>
+        <br id="license">
+        {$link}
+
+	<input type="hidden" value="{$license['deed']}" id="hidden-license-deed" name="license[deed]"/>
+	<input type="hidden" value="{$license['image']}" id="hidden-license-image" name="license[image]"/>
+	<input type="hidden" value="{$license['name']}" id="hidden-license-name" name="license[name]"/>
+
+CONTENT;
+
+	if ( $echo ) {
+		echo $html;
+	} else {
+		return $html;
+	}
     }
 
 

--- a/license-return.php
+++ b/license-return.php
@@ -5,6 +5,9 @@ $license = array(
 	'button' => $_GET["button"],
 	'deed' => $_GET["deed"]
 );
+$license = array_map( function( $retval ) {
+	return filter_var( $retval, FILTER_SANITIZE_STRING );
+}, $license );
 ?>
 <html>
   <head>


### PR DESCRIPTION
This pull request fixes issues with how the "Change License" modal URL is generated, particularly with link argument concatenation.

This allows the plugin to use the old, "Partner Interface" chooser interface: https://wiki.creativecommons.org/wiki/Partner_Interface

Which this plugin relies on, instead of the newer one located here: https://creativecommons.org/choose/

This fixes #52, which I also reported.

Also:
- Commit 6fd11df tidies up how the HTML markup is generated in the `CreativeCommons::select_license_html()` method.
- Commit 9071c39 fixes a potential vulnerability with the modal callback.

Let me know if you have any questions.