### PR TITLE
fix #89 - Completely remove obsolete options and functions

### DIFF
--- a/includes/class-creativecommons-image.php
+++ b/includes/class-creativecommons-image.php
@@ -429,7 +429,7 @@ class CreativeCommonsImage {
 		$meta   = wp_get_attachment_metadata( $att_id, true );
 		$credit = get_post_meta( $att_id, 'attribution_name', true );
 		if ( ( ! $credit )
-			&& isset( $image_metadata['credit'] )
+			&& isset( $meta['credit'] )
 		) {
 			$credit = $meta['image_meta']['credit'];
 		}


### PR DESCRIPTION
Fixes #89
Fixes #87

## Description
This pull request completely remove a set of options from prior versions of this plugin. This options was causing error in some cases (#87 for example) and this options are no longer available in the new versions

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
