### PR TITLE
restore cc0_html_rdfa() function

### DIFF
--- a/includes/class-creativecommons-image.php
+++ b/includes/class-creativecommons-image.php
@@ -457,26 +457,18 @@ class CreativeCommonsImage {
 		if ( $license_url ) {
 			$license_button_url = $this->license_button_url( $license_url );
 			$l                  = CreativeCommons::get_instance();
-			if ( $this->license_url_is_zero( $license_url ) ) {
-				$html_rdfa = $l->cc0_html_rdfa(
-					$title,
-					$attribution_url,
-					$credit
-				);
-			} else {
-				$html_rdfa = $l->license_html_rdfa(
-					$license_url,
-					$license_name,
-					$license_button_url,
-					$title,
-					true, // is_singular.
-					$attribution_url,
-					$credit,
-					$source_work_url,
-					$extras_url,
-					''
-				); // warning_text.
-			}
+			$html_rdfa = $l->license_html_rdfa(
+				$license_url,
+				$license_name,
+				$license_button_url,
+				$title,
+				true, // is_singular.
+				$attribution_url,
+				$credit,
+				$source_work_url,
+				$extras_url,
+				''
+			); // warning_text.
 
 			$button = CreativeCommonsButton::get_instance()->markup(
 				$html_rdfa,

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -996,6 +996,41 @@ class CreativeCommons {
 		return $new_input;
 	}
 
+	/**
+	 * Function: cc0_html_rdfa
+	 *
+	 * @param  mixed $title_work
+	 * @param  mixed $attribute_url
+	 * @param  mixed $attribute_text
+	 */
+	public function cc0_html_rdfa( $title_work, $attribute_url, $attribute_text ) {
+		$result = '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+		<a rel="license"
+		href="http://creativecommons.org/publicdomain/zero/1.0/">
+		<img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" /></a>
+		<br />
+		To the extent possible under law,';
+		if ( $attribute_url ) {
+			$result .= '
+				<a rel="dct:publisher"
+				href="' . $attribute_url . '">
+				<span property="dct:title">' . $attribute_text . '</span></a>';
+		} else {
+			$result .= '
+				<span resource="[_:publisher]" rel="dct:publisher">
+				<span property="dct:title">' . $attribute_text . '</span></span>';
+		}
+		$result .= '  has waived all copyright and related or neighboring rights to
+  		<span property="dct:title">' . $title_work . '</span>.'
+		/*
+		This work is published from:
+		<span property="vcard:Country" datatype="dct:ISO3166"
+		content="' . $country_code . '" about="' . $attribute_url . '">
+		' . $country_name . '</span>.
+		*/
+			. '</p>';
+		return $result;
+	}
 
 	/**
 	 * Print the Section text

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1007,7 +1007,7 @@ class CreativeCommons {
 		$result = '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
 		<a rel="license"
 		href="http://creativecommons.org/publicdomain/zero/1.0/">
-		<img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" /></a>
+		<img src="'.CCPLUGIN__URL.'includes/images/cc0.png" style="border-style: none;" alt="CC0" /></a>
 		<br />
 		To the extent possible under law,';
 		if ( $attribute_url ) {
@@ -1022,12 +1022,6 @@ class CreativeCommons {
 		}
 		$result .= '  has waived all copyright and related or neighboring rights to
   		<span property="dct:title">' . $title_work . '</span>.'
-		/*
-		This work is published from:
-		<span property="vcard:Country" datatype="dct:ISO3166"
-		content="' . $country_code . '" about="' . $attribute_url . '">
-		' . $country_name . '</span>.
-		*/
 			. '</p>';
 		return $result;
 	}

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -997,36 +997,6 @@ class CreativeCommons {
 	}
 
 	/**
-	 * Function: cc0_html_rdfa
-	 *
-	 * @param  mixed $title_work
-	 * @param  mixed $attribute_url
-	 * @param  mixed $attribute_text
-	 */
-	public function cc0_html_rdfa( $title_work, $attribute_url, $attribute_text ) {
-		$result = '<p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
-		<a rel="license"
-		href="http://creativecommons.org/publicdomain/zero/1.0/">
-		<img src="'.CCPLUGIN__URL.'includes/images/cc0.png" style="border-style: none;" alt="CC0" /></a>
-		<br />
-		To the extent possible under law,';
-		if ( $attribute_url ) {
-			$result .= '
-				<a rel="dct:publisher"
-				href="' . $attribute_url . '">
-				<span property="dct:title">' . $attribute_text . '</span></a>';
-		} else {
-			$result .= '
-				<span resource="[_:publisher]" rel="dct:publisher">
-				<span property="dct:title">' . $attribute_text . '</span></span>';
-		}
-		$result .= '  has waived all copyright and related or neighboring rights to
-  		<span property="dct:title">' . $title_work . '</span>.'
-			. '</p>';
-		return $result;
-	}
-
-	/**
 	 * Print the Section text
 	 */
 	public function print_section_info() {


### PR DESCRIPTION
## Fixes
Fixes #114 by @siccovansas

## Description
This PR restore the function `cc0_html_rdfa()` which was previously removed on #76. 
I'm not completely sure if this function is needed but we can discuss about it. In the meantime, this shouldn't generate errors.
Tagging @ahmadbilaldev to get more feedback about this

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
