### PR TITLE
remove hardcoded default license

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -793,10 +793,6 @@ class CreativeCommons {
 				$license['name']  = esc_attr( 'Creative Commons CC0 Universal Public Domain Dedication' );
 				$license['deed']  = esc_url( 'https://creativecommons.org/publicdomain/zero/1.0/' );
 				break;
-			default:    // Uses 'CC BY-SA' as the default license.
-				$license['image'] = esc_attr( CCPLUGIN__URL . 'includes/images/by-sa.png' );
-				$license['name']  = esc_attr( 'Creative Commons Attribution-ShareAlike 4.0 International' );
-				$license['deed']  = esc_url( 'http://creativecommons.org/licenses/by-sa/4.0/' );
 		}
 
 		switch ( $from ) {

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -424,24 +424,24 @@ class CreativeCommons {
 	public function plugin_default_license() {
 		$this->_logger( 'Got default settings' );
 		$license = array(
-			'deed'                       => 'http://creativecommons.org/licenses/by-sa/4.0/',
-			'image'                      => CCPLUGIN__URL . 'includes/images/by-sa.png',
+			'deed'                       => '',
+			'image'                      => '',
 			'attribute_to'               => '',
 			'title'                      => '',
 			'title_url'                  => '',
 			'author'                     => '',
 			'author_url'                 => '',
-			'name'                       => 'Creative Commons Attribution-Share Alike 4.0',
-			'sitename'                   => get_bloginfo( '' ),
-			'siteurl'                    => get_bloginfo( 'url' ),
-			'site_override_license'      => true,
-			'user_override_license'      => true,
-			'content_override_license'   => true,
-			'version'                    => self::VERSION,
-			'additional_attribution_txt' => __( '', 'CreativeCommons' ),
+			'name'                       => '',
+			'sitename'                   => '',
+			'siteurl'                    => '',
+			'site_override_license'      => false,
+			'user_override_license'      => false,
+			'content_override_license'   => false,
+			'version'                    => '',
+			'additional_attribution_txt' => '',
 			'choice'                     => '',
-			'display_as_widget'          => 'false',
-			'display_as_footer'          => 'false',
+			'display_as_widget'          => false,
+			'display_as_footer'          => false,
 		);
 		return $license;
 	}

--- a/widgets/creativecommons-widget.php
+++ b/widgets/creativecommons-widget.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'CreativeCommons_Widget' ) ) {
 		public function print_license_widget() {
 			$ccl     = CreativeCommons::get_instance();
 			$license = $ccl->get_license( $license = 'site' );
-			if ( $license['display_as_widget'] ) {
+			if ( $license['display_as_widget'] && !empty( $license['deed'] ) ) {
 				$ccl->print_license_html();
 			}
 		}
@@ -65,7 +65,7 @@ if ( ! class_exists( 'CreativeCommons_Widget' ) ) {
 		public function print_license_footer() {
 			$ccl     = CreativeCommons::get_instance();
 			$license = $ccl->get_license( $license = 'site' );
-			if ( $license['display_as_footer'] ) {
+			if ( $license['display_as_footer'] && !empty( $license['deed'] ) ) {
 				$ccl->print_license_html();
 			}
 		}


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #118

## Description
This PR removes the default license information which was defined as by-sa 4.0. The default behavior when the plugin is activated do not show the license by default. Also, no default license is defined.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
