### PR TITLE
fix multisite issue retrieving license information

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -494,6 +494,7 @@ class CreativeCommons {
 				$this->_logger( 'called network' );
 				$license = ( $network_license = get_site_option( 'license' ) )
 					? $network_license : $this->plugin_default_license();
+					
 				break;
 
 			case 'site':
@@ -525,22 +526,16 @@ class CreativeCommons {
 			// since this can cause way too many calls for the right license.
 			case 'frontend':
 				$this->_logger( 'get license for the frontend' );
-				if ( is_multisite() ) {
-					$this->_logger( 'get license: multisite' );
-					$license = $this->get_license( 'network' );
-					$this->_logger( 'got network license' );
-				} else {
-					$license = $this->get_license( 'site' );
-					if ( array_key_exists( 'user_override_license', $license )
-					&& 'true' == $license['user_override_license']
-					) {
-						$license = $this->get_license( 'profile' );
-					}
-					if ( array_key_exists( 'content_override_license', $license )
-					&& 'true' == $license['content_override_license']
-					) {
-						$license = $this->get_license( 'post-page' );
-					}
+				$license = $this->get_license( 'site' );
+				if ( array_key_exists( 'user_override_license', $license )
+				&& 'true' == $license['user_override_license']
+				) {
+					$license = $this->get_license( 'profile' );
+				}
+				if ( array_key_exists( 'content_override_license', $license )
+				&& 'true' == $license['content_override_license']
+				) {
+					$license = $this->get_license( 'post-page' );
 				}
 				break;
 		}
@@ -769,7 +764,6 @@ class CreativeCommons {
 		) {
 			$data = sanitize_text_field( wp_unslash( $_POST['license'] ) );
 		}
-
 		// Saves the license attribution information. MAke sure to save the current version.
 		$license['version']             = self::VERSION;
 		$license['attribute_to']        = ( isset( $data['attribute_to'] ) ) ? esc_attr( $data['attribute_to'] ) : '';
@@ -1061,7 +1055,6 @@ class CreativeCommons {
 		 * Add a filter to include the license with the excerpt & content
 		 * filter allow an option to switch this off
 		 */
-
 		$license = $this->get_license( $location );
 		$html = '';
 		if ( is_array( $license ) && count( $license ) > 0 ) {


### PR DESCRIPTION
## Description
This PR fix an issue on multisite installs. The plugins doesn't retrieve license information so the license info shows empty

## Technical details
there was a condition on the `get_license` function which prevent license info from being retrieved. it seems we don't need that condition anymore in current WordPress versions. I'll check this with more detail but for now the problem is solved

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
