### PR TITLE
Add lazy loading attribute to images as needed

### DIFF
--- a/includes/class-creativecommons-image.php
+++ b/includes/class-creativecommons-image.php
@@ -109,7 +109,7 @@ class CreativeCommonsImage {
 			$license_url,
 			$matches
 		);
-        # SHOULD BE ENUMERATIVE.
+		# SHOULD BE ENUMERATIVE.
 		if ( $matched ) {
 			if ( $matches[2] == 'zero' ) {
 				$url = CCPLUGIN__URL . 'includes/attribution-box/cc0.svg';
@@ -673,8 +673,8 @@ class CreativeCommonsImage {
 			'/<img\s[^>]*class="wp-image-(\d+)[^>]*>/',
 			function ($matches) {
 				return
-                    '<div class="cc-attribution-box-container">'
-                    . $matches[0]
+					'<div class="cc-attribution-box-container">'
+					. $matches[0]
 					. '<div class="cc-attribution-box"> '
 					. $this->simple_license_block($matches[1])
 					. '</div></div>';
@@ -697,10 +697,12 @@ class CreativeCommonsImage {
 
 		if (!$button_url) return '';
 
+		$lazy = function_exists('wp_lazy_loading_enabled') && wp_lazy_loading_enabled('img', 'simple_license_block');
+		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		return "<div>" . esc_html($credit) . "</div>"
 			."<a target='_blank' href='" . esc_url($attribution_url) . "'>$title</a>"
 			. "<a class='cc-attribution-box-license' target='_blank' href='" . esc_url($license_url) . "' title='" . esc_attr($license_name) . "'>"
-			. "<img src='" . esc_url($button_url) . "' alt='" . esc_attr($license_name) . "'></a>";
+			. "<img src='" . esc_url($button_url) . "' alt='" . esc_attr($license_name) . " . loading='" . $loading_type . "'></a>";
 	}
 
 }

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -62,8 +62,7 @@ class CreativeCommons {
 		$this->plugin_url = plugin_dir_url( dirname( __FILE__ ) );
 
 		// language setup.
-		$lang_dir = dirname( dirname( plugin_basename( __FILE__ ) ) )
-					. '/languages/';
+		$lang_dir = dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/';
 		load_plugin_textdomain( $this->localization_domain, false, $lang_dir );
 
 		/*

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -61,9 +61,9 @@ class CreativeCommons {
 	public function init() {
 		$this->plugin_url = plugin_dir_url( dirname( __FILE__ ) );
 
-		// language setup.		
-		$lang_dir = dirname( dirname( plugin_basename( __FILE__ ) ) ) 
-                    . '/languages/';
+		// language setup.
+		$lang_dir = dirname( dirname( plugin_basename( __FILE__ ) ) )
+					. '/languages/';
 		load_plugin_textdomain( $this->localization_domain, false, $lang_dir );
 
 		/*
@@ -494,7 +494,7 @@ class CreativeCommons {
 				$this->_logger( 'called network' );
 				$license = ( $network_license = get_site_option( 'license' ) )
 					? $network_license : $this->plugin_default_license();
-					
+
 				break;
 
 			case 'site':
@@ -614,7 +614,7 @@ class CreativeCommons {
 				break;
 
 			default:
-				
+
 				break;
 		}
 
@@ -1127,9 +1127,11 @@ class CreativeCommons {
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
 		list($img_width, $img_height) = getimagesize( $image_url );
+		$lazy = function_exists('wp_lazy_loading_enabled') && wp_lazy_loading_enabled('img', 'license_html_rdfa');
+		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		$html = '';
 		$html .= "<a rel='license' href='$deed_url'>";
-		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='$image_url' width='$img_width' height='$img_height'  />";
+		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='$image_url' width='$img_width' height='$img_height' loading='$loading_type'  />";
 		$html .= '</a><br />';
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Creative Commons ===
 
-Contributors: ahmadbilaldev, cctimidrobot, BjornW, robmyers, tatti, hugosolar
+Contributors: ahmadbilaldev, cctimidrobot, BjornW, robmyers, tatti, hugosolar, kbat82
 Donate link: https://us.netdonor.net/page/6650/donate/1?ea.tracking.id=top-of-page-banner
 Tags: Creative Commons, CC, license, copyright, copyleft, attribution, attribute, ownership, all rights reserved, some rights reserved, footer, widget
 Requires at least: 3.1
@@ -60,6 +60,7 @@ See the GitHub project: [creativecommons/wp-plugin-creativecommons](https://gith
 
 == Changelog ==
 
+* Feature: Adds native lazy loading to CC license images #126
 
 = v2020.09.1 =
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #126 

## Description
Adds the `loading="lazy"` attribute to the image and falls back to `loading="eager"` if the user is below WP 5.5 (where the feature was introduced), or if the user disabled lazy loading.

My text editor auto adjusted some spacing. I left them in because they seemed reasonable enough.

I updated the readme and added my WP name as a contributor, but feel free to remove that if it's not appropriate!

Let me know if I missed something. I don't have a full understanding of the code base, so I may have overlooked something.

## Tests
1. Add a CC license image (from footer, or block).
2. Check the image attribute

To disable:
1. Downgrade WP. If using CLI, the following should work. The `--path` is optional depending on your setup.
```sh
wp core update --path="htdocs/cms" --version="5.4" --force
```
2. Add a filter to functions.php or as a mu-plugin
```sh
add_filter('wp_lazy_loading_enabled', '__return_false');
```

## Screenshots
<img width="573" alt="Screen Shot 2020-09-26 at 10 29 59 PM" src="https://user-images.githubusercontent.com/1478421/94344204-e5063780-0047-11eb-89e1-abb397f2db8e.png">

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
