### PR TITLE
Only render title when it exists

### DIFF
--- a/widgets/creativecommons-widget.php
+++ b/widgets/creativecommons-widget.php
@@ -80,8 +80,18 @@ if ( ! class_exists( 'CreativeCommons_Widget' ) ) {
 		public function widget( $args, $instance ) {
 			$title = apply_filters( 'widget_title', $instance['title'] );
 			echo $args['before_widget'];
-			echo $args['before_title'] . $title . $args['after_title'];
+
+			/*
+			* To prevent rendering padding on an empty heading tag
+			* only render title when it exists (and isn't an empty string)
+			*/
+			$title_exists = $title && $title != "";
+			
+			if ($title_exists)
+				echo $args['before_title'] . $title . $args['after_title'];
+
 			$this->print_license_widget( );
+			
 			echo $args['after_widget'];
 		}
 

--- a/widgets/creativecommons-widget.php
+++ b/widgets/creativecommons-widget.php
@@ -85,7 +85,7 @@ if ( ! class_exists( 'CreativeCommons_Widget' ) ) {
 			* To prevent rendering an empty heading tag (and related margin)
 			* only render title when it exists (and isn't an empty string)
 			*/
-			$title_exists = $title && $title != "";
+			$title_exists = isset($title) && !empty(trim($title));
 			
 			if ($title_exists) {
 				echo $args['before_title'] . $title . $args['after_title'];

--- a/widgets/creativecommons-widget.php
+++ b/widgets/creativecommons-widget.php
@@ -87,8 +87,9 @@ if ( ! class_exists( 'CreativeCommons_Widget' ) ) {
 			*/
 			$title_exists = $title && $title != "";
 			
-			if ($title_exists)
+			if ($title_exists) {
 				echo $args['before_title'] . $title . $args['after_title'];
+			}
 
 			$this->print_license_widget( );
 			

--- a/widgets/creativecommons-widget.php
+++ b/widgets/creativecommons-widget.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'CreativeCommons_Widget' ) ) {
 			echo $args['before_widget'];
 
 			/*
-			* To prevent rendering padding on an empty heading tag
+			* To prevent rendering an empty heading tag (and related margin)
 			* only render title when it exists (and isn't an empty string)
 			*/
 			$title_exists = $title && $title != "";


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #148 by @NicoHood

## Description
<!-- Concisely describe what the pull request does. -->
Only render the widget title when the title exists and isn't an empty string.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
1. add the CC widget to a theme
2. save the widget's settings without a title
3. inspect the markup on the rendered output
4. notice there isn't an empty heading tag
5. save the widget's settings with a title
6. notice the title renders correctly
7. optionally save the title with just an empty space
8. the title should not render due to string trim

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
Before:
![image](https://user-images.githubusercontent.com/17307/116350613-e32d6e00-a7fa-11eb-8aa8-e7bd5112ca5d.png)


After:
![image](https://user-images.githubusercontent.com/17307/116350700-0bb56800-a7fb-11eb-84ba-fc88a3f0b2ba.png)


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
