### PR TITLE
drop develop branch and cleanup formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,6 @@ guidelines on the Creative Common Open Source website.
 
 ### Development
 
-Master branch is for the releases. Development will be done in the development
-branch.  Occasionally other branches may be available to test new features or
-play with new ideas, but they may be deleted anytime so don't rely on those
-branches. To start contributing code, checkout the `develop` branch.
 
 ### WordPress Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -8,35 +8,42 @@
 
 </div>
 
+
 ## Description
 
-The plugin is an attribution tool. It has multiple features that allow users to attribute their content by including Creative Commons license
-([Choose a License](https://creativecommons.org/choose/)) on their WordPress website. This includes default, post, page and media attribution.
+The plugin is an attribution tool. It has multiple features that allow users to
+attribute their content by including Creative Commons license ([Choose a
+License](https://creativecommons.org/choose/)) on their WordPress website. This
+includes default, post, page and media attribution.
+
 
 ## Installation
 
-Download the latest version from this project's [releases][releases]. You can install the plugin to your WP website
-using any of these methods:
+Download the latest version from this project's [releases][releases]. You can
+install the plugin to your WP website using any of these methods:
 
 [releases]: https://github.com/creativecommons/creativecommons-wordpress-plugin/releases "Releases · creativecommons/creativecommons-wordpress-plugin"
 
-1. In your plugin Dashboard on WordPress, Click **Add New** and
-upload the plugin `.zip` file. When installed, activate the plugin.
+1. In your plugin Dashboard on WordPress, Click **Add New** and upload the
+   plugin `.zip` file. When installed, activate the plugin.
 2. Extract the `.zip` file and paste the extracted folder to the
-   "/wp-content/plugins/" directory. Go to your plugin Dashboard and activate the plugin.
+   "/wp-content/plugins/" directory. Go to your plugin Dashboard and activate
+   the plugin.
 
 
 ## Features
 
+
 ### Setting a Default Site License
 
-After activating the plugin, head to **Settings > Creative Commons** to set up the default license.
+After activating the plugin, head to **Settings > Creative Commons** to set up
+the default license.
 
 ![Plugin Settings](https://cl.ly/01ae314c5c57/img)
 
-Selecting a license is simple. Select one from the given
-CC licenses, by default [**CC BY-SA**](http://creativecommons.org/licenses/by-sa/4.0/)
-license is used.
+Selecting a license is simple. Select one from the given CC licenses, by
+default [**CC BY-SA**](http://creativecommons.org/licenses/by-sa/4.0/) license
+is used.
 
 ![Select License](https://cl.ly/bfd84b912c78/img)
 
@@ -50,29 +57,30 @@ can add:
 
 ![License Options](https://cl.ly/b4520d6ab6b1/img)
 
+
 ### Widget
 
-There are two options to display the default license, as
-a widget or in the footer. We recommend using the widget for better theme compatibility.
+There are two options to display the default license, as a widget or in the
+footer. We recommend using the widget for better theme compatibility.
 
 ![Widget](https://cl.ly/2dacc1739955/img)
 
-After selecting the widget go to **Appearance > Widgets**
-and drag the CC License Widget to the
-required area. The widget will then display the default license on all pages of the site.
+After selecting the widget go to **Appearance > Widgets** and drag the CC
+License Widget to the required area. The widget will then display the default
+license on all pages of the site.
 
 ![Widget Front-end](https://cl.ly/b9b584688f46/img)
 
+
 ### Gutenberg Blocks
 
-The plugin adds specific Gutenberg blocks for each Creative
-Commons license. If you are using the default Gutenberg editor,
-you will find these blocks under a separate category.
+The plugin adds specific Gutenberg blocks for each Creative Commons license. If
+you are using the default Gutenberg editor, you will find these blocks under a
+separate category.
 
 ![Blocks Category](https://cl.ly/4934cdc59cd4/img)
 
-These blocks can be used to license any page/post/image or
-other media.
+These blocks can be used to license any page/post/image or other media.
 
 ![Blocks Back-end](https://cl.ly/b454a77259ce/img)
 
@@ -93,22 +101,14 @@ At a glance, with WP CC Plugin you can:
 - License posts and pages by simply including CC Gutenberg blocks for each
   license required (Gutenberg License Blocks)
 
+
 ## Contributing
 
 Contributions will be very appreciated. See
 [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 
-## Development
-
-If you're interested in the code have a look at the master branch for the
-releases. Development will be done in the develop branch.
-
-Occasionally other branches may be available to test new features or play with
-new ideas, but they may be deleted anytime so don't rely on those branches.
-
-
-### Release Schedule
+## Release Schedule
 
 We will release a new version every month that there are substantial changes.
 See [milestones][milestones] for how GitHub issues are assigned for release.
@@ -120,8 +120,8 @@ See [milestones][milestones] for how GitHub issues are assigned for release.
 
 This plugin is loosely based on an existing, but seemingly abandoned WordPress
 plugin named 'License' (a component of the [MIT Educational Collaboration
-Space][collabspace] project) by mitcho (Michael Yoshitaka Erlewine) and
-Brett Mellor. We're also inspired by Creative Commons' original
+Space][collabspace] project) by mitcho (Michael Yoshitaka Erlewine) and Brett
+Mellor. We're also inspired by Creative Commons' original
 [wordpress-cc-plugin][oldplugin] written by former Creative Commons CTO Nathan
 Yergler.
 
@@ -131,12 +131,12 @@ Yergler.
 
 ### Credits
 
-* Michael Yoshitaka Erlewine (License v0.5)
-* Brett Mellor (License v0.5)
-* Bjorn Wijers
-* Matt Lee
-* Rob Myers
-* Tarmo Toikkanen
+- Michael Yoshitaka Erlewine (License v0.5)
+- Brett Mellor (License v0.5)
+- Bjorn Wijers
+- Matt Lee
+- Rob Myers
+- Tarmo Toikkanen
 
 
 ## License


### PR DESCRIPTION
## Description
drop develop branch and cleanup formatting
- The `develop` branch was used to refactor this project and is no longer needed.
- Reflow text to 80 chars, make whitespace (newlines) before heading consistent, and list formatting consistent

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- `N/A` I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
