### PR TITLE
update version to v2021.04.1

### DIFF
--- a/creativecommons.php
+++ b/creativecommons.php
@@ -3,7 +3,7 @@
  * Plugin Name: Creative Commons
  * Plugin URI: https://github.com/creativecommons/wp-plugin-creativecommons
  * Description: Official Creative Commons plugin for licensing your content. With Creative Commons licenses, keep your copyright AND share your creativity.
- * Version: 2020.11.1
+ * Version: 2021.04.1
  * Author: Ahmad Bilal <https://ahmadbilal.dev>, Bjorn Wijers <burobjorn@burobjorn.nl>, Tarmo Toikkanen <tarmo@iki.fi>, Matt Lee <mattl@creativecommons.org>, Rob Myers <rob@creativecommons.org>, Timid Robot Zehta
  * Author URI: http://CreativeCommons.org/
  * License: GPLv2 or later versions

--- a/dev/README.md
+++ b/dev/README.md
@@ -11,13 +11,13 @@
    2. GitHub tag for the version
    3. Path to the Subversion repository checkout
     ```
-    ./dev/prep_svn_release.sh cctimidrobot v2020.11.1 \
+    ./dev/prep_svn_release.sh cctimidrobot v2021.04.1 \
         ../../svn/wordpress-org-creative-commons/
     ```
 4. From the Subversion repositry checkout, copy and commit Subversion tag:
     ```
-    svn copy trunk/ tags/2020.11.1/
-    svn commit --username=cctimidrobot -m'Tagging version 2020.11.1'
+    svn copy trunk/ tags/2021.04.1/
+    svn commit --username=cctimidrobot -m'Tagging version 2021.04.1'
     ```
 
 ### Notes

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -8,7 +8,7 @@
 class CreativeCommons {
 
 	// Make sure the plugin header has the same version number.
-	const VERSION = '2020.11.1';
+	const VERSION = '2021.04.1';
 
 	/**
 	 * Plugin URL.

--- a/languages/CreativeCommons.pot
+++ b/languages/CreativeCommons.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the same license as the Creative Commons plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Creative Commons 2020.11.1\n"
+"Project-Id-Version: Creative Commons 2021.04.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-plugin-creativecommons\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://creativecommons.org/donate
 Tags: Creative Commons, CC, license, copyright, copyleft, attribution, attribute, ownership, all rights reserved, some rights reserved, footer, widget
 Requires at least: 3.1
 Tested up to: 5.4
-Stable tag: 2020.11.1
+Stable tag: 2021.04.1
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://gnu.org/licenses/gpl-2.0.html
@@ -59,6 +59,13 @@ See the GitHub project: [creativecommons/wp-plugin-creativecommons](https://gith
 
 
 == Changelog ==
+
+
+= v2021.04.1 =
+
+* Fixed: Empty title adds extra padding #148
+* Fixed: Remove outdated language files #108
+* Fixed: Update donation link #139
 
 
 = v2020.11.1 =


### PR DESCRIPTION
## Fixes
Related to #155 

## Description
update version to v2021.04.1

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- `N/A` I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
