### PR TITLE
docs: update wpcs instructions to prevent errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,12 @@ If you are not setup to detect WPCS errors, consider the following steps.
    git clone https://github.com/WordPress/WordPress-Coding-Standards.git
    ```
 
+   After this you'll need to switch to the master branch of this repo.
+   ```shell
+   cd wpcs
+   git checkout master
+   ```
+
 5. **Tell PHPCS about this directory**
 
    We need to add the ~/wpcs folder, where we cloned wpcs, to the installed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,20 +72,14 @@ If you are not setup to detect WPCS errors, consider the following steps.
 4. **Setup WPCS**
 
    Clone the official [WordPress Coding Standards repository][wpcs-repo] in
-   your home folder. To do so, run the following commands:
-   if using ssh
+   your home folder and ensure you are using its `master` branch:
    ```shell
-   cd
-   git clone git@github.com:WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
+   git clone https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
    ```
-   if using https
-   ```shell
-   git clone https://github.com/WordPress/WordPress-Coding-Standards.git
-   ```
-
-   After this you'll need to switch to the master branch of this repo.
    ```shell
    cd wpcs
+   ```
+   ```shell
    git checkout master
    ```
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #[issue number] by @[issue author]

## Description
Updates wpcs instructions to prevent error `Getting PHPCS Response ERROR: Referenced sniff "PHPCSUtils" does not exist`.

## Technical details
Related to https://github.com/squizlabs/PHP_CodeSniffer/issues/3110

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
