### PR TITLE
Fix for issue #209: CC plugin admin fails to load with PHP 8

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -924,7 +924,7 @@ class CreativeCommons {
 		<div style="background: white; border: 1px solid #e5e5e5; box-shadow: 0 1px 1px rgba(0,0,0,.04); padding: 2em; display: inline-table;">
 
 		<?php
-			printf( '<img src="%1$s" align="right" style="padding: 1em; width: 20%; height: auto !important; " />', esc_attr( CCPLUGIN__URL ) . 'assets/icon-256x256.png' );
+			printf( '<img src="%1$s" align="right" style="padding: 1em; width: 20%%; height: auto !important;" />', esc_attr( CCPLUGIN__URL ) . 'assets/icon-256x256.png' );
 		?>
 
 		<h3>About Creative Commons</h3>


### PR DESCRIPTION
## Fixes
Fixes #209 by @xolotl

## Description
Escapes percent character to avoid fatal error in PHP 8. Also removes unnecessary space in same line of code.

## Technical details
Apparently the unescaped percent sign in line 927 was not a fatal error in PHP 7, but is in PHP 8. This screenshot shows how the output was generated, but was incorrect in PHP 7 (no percent sign):

<img width="1422" alt="Settings_Admin_‹_Nate_Angell_—_WordPress" src="https://user-images.githubusercontent.com/997548/182064920-363f1666-41af-4b41-b8e5-c4afce897ef8.png">

This screenshot shows how the output is generated correctly with the fix in both PHP 7 and 8 (with a percent sign):

<img width="1429" alt="Settings_Admin_‹_Nate_Angell_—_WordPress" src="https://user-images.githubusercontent.com/997548/182064989-a8d64b43-e2d1-4cd2-9704-0afc0560924d.png">

## Tests
See issue reproduction details in #209.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
