### PR TITLE
Warning: getimagesize: failed to open stream

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1125,7 +1125,7 @@ class CreativeCommons {
 									$title_work, $is_singular, $attribute_url,
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
-		list($img_width, $img_height) = getimagesize( $image_url );
+		list($img_width, $img_height) = wp_get_attachment_image_src( $image_url );
 		$lazy = function_exists('wp_lazy_loading_enabled') && wp_lazy_loading_enabled('img', 'license_html_rdfa');
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		$html = '';

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1129,7 +1129,7 @@ class CreativeCommons {
 		$lazy = function_exists('wp_lazy_loading_enabled') && wp_lazy_loading_enabled('img', 'license_html_rdfa');
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		$html = '';
-		$html .= "<a rel='license' href='$deed_url'>";
+		$html .= "<a rel='license' target='_blank' href='$deed_url'>";
 		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='$image_url' width='$img_width' height='$img_height' loading='$loading_type'  />";
 		$html .= '</a><br />';
 
@@ -1154,7 +1154,7 @@ class CreativeCommons {
 			$html .= sprintf( __( 'on this site ', 'CreativeCommons' ) );
 		}
 
-		$html .= sprintf( __( ' is licensed under a <a rel="license" href="%1$s">%2$s</a> License.', 'CreativeCommons' ), $deed_url, $license_name );
+		$html .= sprintf( __( ' is licensed under a <a rel="license" target="_blank" href="%1$s">%2$s</a> License.', 'CreativeCommons' ), $deed_url, $license_name );
 		if ( $source_work_url ) {
 			$html .= '<br />';
 			$html .= sprintf( __( 'Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="%s" rel="dct:source">%s</a>.', 'CreativeCommons' ), $source_work_url, $source_work_url );


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #187  by @brylie 

## Description
<!-- Concisely describe what the pull request does. -->
Changed "getimagesize" to "wp_get_attachment_image_src"

## Screenshots

Original Error:
![image](https://github.com/creativecommons/wp-plugin-creativecommons/assets/112554159/02192d36-d8d6-470a-a628-79a895652c44)
After code change
![image](https://github.com/creativecommons/wp-plugin-creativecommons/assets/112554159/273f6585-774f-4f3b-b071-4e2e7da0227f)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
