### PR TITLE
added css and media query for footer display license's alignment

### DIFF
--- a/css/cc-footer-license.css
+++ b/css/cc-footer-license.css
@@ -1,0 +1,22 @@
+.license-wrap {
+	margin: 25px auto;
+	max-width: calc(70vw - 4 * 25px);
+}
+
+@media (max-width: 767px) {
+	.license-wrap {
+		max-width: 90vw;
+	}
+}
+
+@media (min-width: 992px) {
+	.license-wrap {
+		max-width: 75vw;
+	}
+}
+
+@media (min-width: 1300px) {
+	.license-wrap {
+		max-width: 65vw;
+	}
+}

--- a/src/init.php
+++ b/src/init.php
@@ -86,3 +86,9 @@ function cc_block_cgb_block_assets() { // phpcs:ignore
 
 // Hook: Block assets.
 add_action( 'init', 'cc_block_cgb_block_assets' );
+
+// Register Footer License CSS
+function cc_footer_license() {
+	wp_enqueue_style('cc-footer-license', plugins_url('./css/cc-footer-license.css', dirname(__FILE__)));
+}
+add_action('wp_enqueue_scripts', 'cc_footer_license');


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes [#[204]](https://github.com/creativecommons/wp-plugin-creativecommons/issues/204) by @[[possumbilities](https://github.com/possumbilities)]

## Description
<!-- Concisely describe what the pull request does. -->
- Added appropriate margin, width, and media query to the footer display option for better alignment.
- Ensured that the license details now display with parity to the active theme.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
Provide step-by-step instructions for testing the changes:

1. Install the plugin version with these changes.
2. Enable the footer display option.
3. Verify that the license details are now properly aligned with the active theme.

## Screenshots
### Twenty Twenty-four Theme
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->
#### Desktop Screen:
![image](https://github.com/creativecommons/wp-plugin-creativecommons/assets/106741653/45c3c45f-5d36-4f15-82de-113022c200b5)
#### Tablet Screen:
![image](https://github.com/creativecommons/wp-plugin-creativecommons/assets/106741653/0612fd89-3dbe-4458-9ea3-f112e316eccc)
#### Mobile Device:
![image](https://github.com/creativecommons/wp-plugin-creativecommons/assets/106741653/0e528636-5170-4574-94ea-f4c3c6c77a61)

### Twenty Twenty-one Theme

#### Desktop Screen:
![Screenshot_58](https://github.com/creativecommons/wp-plugin-creativecommons/assets/106741653/5a9846f9-f6b9-4c0f-9ed9-7f886932f5d0)

#### Tablet Screen:
![Screenshot_59](https://github.com/creativecommons/wp-plugin-creativecommons/assets/106741653/22f47f03-f3ba-4bfb-af5f-10b1c1146b3b)

#### Mobile Device
![image](https://github.com/creativecommons/wp-plugin-creativecommons/assets/106741653/858129f3-061f-4f7f-95e9-de1769253d52)


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
