### PR TITLE
Refactor: Update getimagesize() Function to Accept Image Paths Instead of URLs

### DIFF
--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1058,26 +1058,13 @@ class CreativeCommons {
 		$html = '';
 		if ( is_array( $license ) && count( $license ) > 0 ) {
 			$deed_url     = esc_url( $license['deed'] );
-			// $image_url    = esc_url( $license['image'] );
-			$image_data = array(
-				'url' => esc_url( $license['image'] ),
-				'size' => null
-			);
+			$image_url    = esc_attr( $license['image'] );
 			$license_name = esc_attr( $license['name'] );
 			$title        = esc_attr( $license['title'] );
 			$title_url    = esc_url( $license['title_url'] );
 			$author       = esc_attr( $license['author'] );
 			$author_url   = esc_url( $license['author_url'] );
 
-			if(!empty($image_data['url'])){
-				$image_size = getimagesize($image_data['url']);
-				if(is_array($image_size)){
-					$image_data['size'] = array(
-						'width' => $image_size[0],
-						'height' => $image_size[1]
-					);
-				}
-			}
 
 			$additional_attribution_txt = ( array_key_exists( 'additional_attribution_txt', $license ) )
 						? esc_html( $license['additional_attribution_txt'] ) : '';
@@ -1108,7 +1095,7 @@ class CreativeCommons {
 				. $this->license_html_rdfa(
 					$deed_url,
 					$license_name,
-					$image_data,
+					$image_url,
 					$title_work,
 					is_singular(),
 					$attribute_url,
@@ -1134,16 +1121,20 @@ class CreativeCommons {
 	/**
 	 * Function: license_html_rdfa
 	 */
-	public function license_html_rdfa( $deed_url, $license_name, $image_data,
+	public function license_html_rdfa( $deed_url, $license_name, $image_url,
 									$title_work, $is_singular, $attribute_url,
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
+		$image_path = str_replace( CCPLUGIN__URL, '', $image_url );
+		$image_path = CCPLUGIN__DIR . $image_path;
+
+		list( $img_width, $img_height ) = getimagesize( $image_path );
 
 		$lazy = function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'license_html_rdfa' );
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		$html  = '';
 		$html .= "<a rel='license' href='$deed_url'>";
-		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='". $image_data['url']. "' width='". $image_data['size']['width']. "' height='". $image_data['size']['height']. "' loading='$loading_type'  />";
+		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='$image_url' width='$img_width' height='$img_height' loading='$loading_type'  />";
 		$html .= '</a><br />';
 
 

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1058,13 +1058,26 @@ class CreativeCommons {
 		$html = '';
 		if ( is_array( $license ) && count( $license ) > 0 ) {
 			$deed_url     = esc_url( $license['deed'] );
-			$image_url    = esc_attr( $license['image'] );
+			// $image_url    = esc_url( $license['image'] );
+			$image_data = array(
+				'url' => esc_url( $license['image'] ),
+				'size' => null
+			);
 			$license_name = esc_attr( $license['name'] );
 			$title        = esc_attr( $license['title'] );
 			$title_url    = esc_url( $license['title_url'] );
 			$author       = esc_attr( $license['author'] );
 			$author_url   = esc_url( $license['author_url'] );
 
+			if(!empty($image_data['url'])){
+				$image_size = getimagesize($image_data['url']);
+				if(is_array($image_size)){
+					$image_data['size'] = array(
+						'width' => $image_size[0],
+						'height' => $image_size[1]
+					);
+				}
+			}
 
 			$additional_attribution_txt = ( array_key_exists( 'additional_attribution_txt', $license ) )
 						? esc_html( $license['additional_attribution_txt'] ) : '';
@@ -1095,7 +1108,7 @@ class CreativeCommons {
 				. $this->license_html_rdfa(
 					$deed_url,
 					$license_name,
-					$image_url,
+					$image_data,
 					$title_work,
 					is_singular(),
 					$attribute_url,
@@ -1121,20 +1134,16 @@ class CreativeCommons {
 	/**
 	 * Function: license_html_rdfa
 	 */
-	public function license_html_rdfa( $deed_url, $license_name, $image_url,
+	public function license_html_rdfa( $deed_url, $license_name, $image_data,
 									$title_work, $is_singular, $attribute_url,
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
-		$image_path = str_replace( CCPLUGIN__URL, '', $image_url );
-		$image_path = CCPLUGIN__DIR . $image_path;
-
-		list( $img_width, $img_height ) = getimagesize( $image_path );
 
 		$lazy = function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'license_html_rdfa' );
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		$html  = '';
 		$html .= "<a rel='license' href='$deed_url'>";
-		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='$image_url' width='$img_width' height='$img_height' loading='$loading_type'  />";
+		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='". $image_data['url']. "' width='". $image_data['size']['width']. "' height='". $image_data['size']['height']. "' loading='$loading_type'  />";
 		$html .= '</a><br />';
 
 

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1125,10 +1125,14 @@ class CreativeCommons {
 									$title_work, $is_singular, $attribute_url,
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
-		list($img_width, $img_height) = getimagesize( $image_url );
-		$lazy = function_exists('wp_lazy_loading_enabled') && wp_lazy_loading_enabled('img', 'license_html_rdfa');
+		$image_path = str_replace( CCPLUGIN__URL, '', $image_url );
+		$image_path = CCPLUGIN__DIR . $image_path;
+
+		list( $img_width, $img_height ) = getimagesize( $image_path );
+
+		$lazy = function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'license_html_rdfa' );
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
-		$html = '';
+		$html  = '';
 		$html .= "<a rel='license' href='$deed_url'>";
 		$html .= "<img alt='" . __( 'Creative Commons License', 'CreativeCommons' ) . "' style='border-width:0' src='$image_url' width='$img_width' height='$img_height' loading='$loading_type'  />";
 		$html .= '</a><br />';

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1125,7 +1125,7 @@ class CreativeCommons {
 									$title_work, $is_singular, $attribute_url,
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
-		$image_path = str_replace( CCPLUGIN__URL, CCPLUGIN__DIR, $image_url );
+		$image_path = str_replace( esc_attr( CCPLUGIN__URL ), esc_attr( CCPLUGIN__DIR ), $image_url );
 		list( $img_width, $img_height ) = getimagesize( $image_path );
 		$lazy = function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'license_html_rdfa' );
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default

--- a/includes/class-creativecommons.php
+++ b/includes/class-creativecommons.php
@@ -1125,11 +1125,8 @@ class CreativeCommons {
 									$title_work, $is_singular, $attribute_url,
 									$attribute_text, $source_work_url,
 									$extra_permissions_url, $additional_attribution_txt, $title, $title_url, $author, $author_url ) {
-		$image_path = str_replace( CCPLUGIN__URL, '', $image_url );
-		$image_path = CCPLUGIN__DIR . $image_path;
-
+		$image_path = str_replace( CCPLUGIN__URL, CCPLUGIN__DIR, $image_url );
 		list( $img_width, $img_height ) = getimagesize( $image_path );
-
 		$lazy = function_exists( 'wp_lazy_loading_enabled' ) && wp_lazy_loading_enabled( 'img', 'license_html_rdfa' );
 		$loading_type = $lazy ? 'lazy' : 'eager'; // 'eager' is the browser default
 		$html  = '';


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #187 by @brylie

## Description
<!-- Concisely describe what the pull request does. -->
The function ` getimagesize() ` takes image as parameter and returns the image size i.e height and width. In this PR, we replace image url with image path to fix this issue.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->
This issue doesn't occur everytime, however in some cases when a website: 
- Has basic auth
- Timesout while loading the image

the image may not be accessible through the image url, hence calling the ` getimagesize() ` with image url may not work always. Also everytime ` getimagesize() ` function is called, the server sends a request to load the image increasing execution time. Hence I've chosen to pass image path instead of image url in ` getimagesize() `. This solution handles the above 2 cases as well as addresses the performace issue of the code.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->
As described above, this situation doesn't always occur, so it may be difficult to test.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
