### PR TITLE
Replace the master branch to main branch in development.md

### DIFF
--- a/development.md
+++ b/development.md
@@ -69,7 +69,7 @@ If you are not setup to detect WPCS errors, consider the following steps.
 4. **Setup WPCS**
 
    Clone the official [WordPress Coding Standards repository][wpcs-repo] in
-   your home folder and ensure you are using its `master` branch:
+   your home folder and ensure you are using its `main` branch:
    ```shell
    git clone https://github.com/WordPress/WordPress-Coding-Standards.git wpcs
    ```
@@ -77,7 +77,7 @@ If you are not setup to detect WPCS errors, consider the following steps.
    cd wpcs
    ```
    ```shell
-   git checkout master
+   git checkout main
    ```
 
 5. **Tell PHPCS about this directory**


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'.  -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #235  by @manishsindur

## Description
<!-- Concisely describe what the pull request does. -->
This PR updates the development.md file by replacing references to the master branch with main in the Recommended Setup for WordPress Coding Standards section. This change aligns the language with the current best practices of inclusive terminology.

- Updated master to main in step 4 of the setup guide.
- This PR addresses the issue reported in https://github.com/creativecommons/wp-plugin-creativecommons/issues/235 .

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->
Tested the new setup instructions by following the steps in a fresh environment. Everything works as expected with the main branch.

## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->
<img width="995" alt="Screenshot 2024-10-25 at 1 43 44 AM" src="https://github.com/user-attachments/assets/7205a9fe-3587-4c1b-bb81-219578def8cc">

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
